### PR TITLE
Adding image IO dependencies

### DIFF
--- a/docker-keras-tensorflow-python3-jupyter/Dockerfile
+++ b/docker-keras-tensorflow-python3-jupyter/Dockerfile
@@ -37,6 +37,9 @@ RUN pip --no-cache-dir install \
 	textblob \
 	spacy \
 	lesscpy \
+	git+https://github.com/pydicom/pydicom \ 
+	SimpleITK>=1.0.0 \
+	nibabel >= 2.1.0 \
         && \
     python3 -m ipykernel.kernelspec
 


### PR DESCRIPTION
as a response to (https://github.com/ImagingInformatics/machine-learning/issues/1)
adding the newest version of the pydicom library(1.0 build, not on pip) for handing single images and their metadata. 
adding SimpleITK for handling 3D/4D image data from DICOM/mhd files
adding nibabel for handling various neuroformats like Nifti